### PR TITLE
updated str2buf with base58 option and specified encoding for massages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "brambljs",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1718,15 +1718,6 @@
       "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==",
       "dev": true
     },
-    "keccak": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.0.tgz",
-      "integrity": "sha512-/4h4FIfFEpTEuySXi/nVFM5rqSKPnnhI7cL4K3MFSwoI3VyM7AhPSq3SsysARtnEBEeIKMBUWD8cTh9nHE8AkA==",
-      "requires": {
-        "node-addon-api": "^2.0.0",
-        "node-gyp-build": "^4.2.0"
-      }
-    },
     "levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -1910,11 +1901,6 @@
         }
       }
     },
-    "node-addon-api": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.0.tgz",
-      "integrity": "sha512-ASCL5U13as7HhOExbT6OlWJJUV/lLzL2voOSP1UVehpRD8FbSrSDjfScK/KwAvVTI5AS6r4VwbOMlIqtvRidnA=="
-    },
     "node-environment-flags": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
@@ -1929,11 +1915,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
       "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
-    },
-    "node-gyp-build": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.0.tgz",
-      "integrity": "sha512-4oiumOLhCDU9Rronz8PZ5S4IvT39H5+JEv/hps9V8s7RSLhsac0TCP78ulnHXOo8X1wdpPiTayGlM1jr4IbnaQ=="
     },
     "normalize-path": {
       "version": "3.0.0",

--- a/src/Brambl.js
+++ b/src/Brambl.js
@@ -186,16 +186,16 @@ class Brambl {
 Brambl.prototype.addSigToTx = async function(prototypeTx, userKeys) {
   // function for generating a signature in the correct format
   const genSig = (keys, txMsgToSign) => {
-    return Object.fromEntries( 
-        keys.map( 
+    return Object.fromEntries(
+        keys.map(
             (key) => {
-              const pubKeyHashByte = Buffer.from("01", "hex")
-              const prop = Buffer.concat([pubKeyHashByte, base58.decode(key.pk)], 33)
-              const sig = Buffer.concat([pubKeyHashByte, key.sign(txMsgToSign)], 65)
-              return [base58.encode(prop), base58.encode(sig)]
+              const pubKeyHashByte = Buffer.from("01", "hex");
+              const prop = Buffer.concat([pubKeyHashByte, base58.decode(key.pk)], 33);
+              const sig = Buffer.concat([pubKeyHashByte, key.sign(txMsgToSign)], 65);
+              return [base58.encode(prop), base58.encode(sig)];
             }
-          )
-      );
+        )
+    );
   };
 
   // list of Key Managers

--- a/src/Brambl.js
+++ b/src/Brambl.js
@@ -186,7 +186,16 @@ class Brambl {
 Brambl.prototype.addSigToTx = async function(prototypeTx, userKeys) {
   // function for generating a signature in the correct format
   const genSig = (keys, txMsgToSign) => {
-    return Object.fromEntries( keys.map( (key) => [key.pk, base58.encode(key.sign(txMsgToSign))]));
+    return Object.fromEntries( 
+        keys.map( 
+            (key) => {
+              const pubKeyHashByte = Buffer.from("01", "hex")
+              const prop = Buffer.concat([pubKeyHashByte, base58.decode(key.pk)], 33)
+              const sig = Buffer.concat([pubKeyHashByte, key.sign(txMsgToSign)], 65)
+              return [base58.encode(prop), base58.encode(sig)]
+            }
+          )
+      );
   };
 
   // list of Key Managers

--- a/src/modules/KeyManager.js
+++ b/src/modules/KeyManager.js
@@ -162,7 +162,7 @@ class KeyManager {
      */
     static verify(publicKey, message, signature) {
       const pk = str2buf(publicKey);
-      const msg = str2buf(message, "utf8");
+      const msg = str2buf(message, "base58");
       const sig = str2buf(signature);
 
       return curve25519.verify(pk, msg, sig);
@@ -289,7 +289,7 @@ class KeyManager {
       if (!this.#sk) throw new Error("A key must be initialized before using this key manager");
       if (!message || message.constructor !== String) throw new Error("Invalid message provided as argument.");
 
-      return curve25519.sign(str2buf(this.#sk), str2buf(message, "utf8"), crypto.randomBytes(64));
+      return curve25519.sign(str2buf(this.#sk), str2buf(message, "base58"), crypto.randomBytes(64));
     }
 
     /**

--- a/src/utils/key-utils.js
+++ b/src/utils/key-utils.js
@@ -20,16 +20,16 @@ const utils = require("../utils/address-utils.js");
 /* ------------------------------ Generic key utils  ------------------------------ */
 
 /**
- * Convert a string to a Buffer.  If encoding is not specified, hex-encoding
- * will be used if the input is valid hex.  If the input is valid base64 but
- * not valid hex, base64 will be used.  Otherwise, utf8 will be used.
+ * Convert a string to a Buffer with optional Node builtin encoding specified.
+ * If encoding is not specified, Base58 encoding will be assumed, if the input is valid.
  * @param {string} str String to be converted.
  * @param {string=} enc Encoding of the input string (optional).
  * @returns {Buffer} Buffer (bytearray) containing the input data.
  */
 function str2buf(str, enc) {
   if (!str || str.constructor !== String) return str;
-  return enc ? Buffer.from(str, enc) : Buffer.from(Base58.decode(str));
+  else if (enc === "base58") return Buffer.from(Base58.decode(str));
+  else return enc ? Buffer.from(str, enc) : Buffer.from(Base58.decode(str));
 }
 
 /**
@@ -145,7 +145,7 @@ function deriveKey(password, salt, kdfParams) {
   }
 
   // convert strings to Buffers
-  password = str2buf(password, "utf8");
+  password = str2buf(password, "latin1");
   salt = str2buf(salt);
 
   // get scrypt parameters

--- a/test/testScripts/chainInfoTest.js
+++ b/test/testScripts/chainInfoTest.js
@@ -2,10 +2,11 @@ require("dotenv").config();
 const brambl = require("../../index");
 
 brambl.Requests("https://valhalla.torus.topl.co/", process.env.VALHALLA_KEY)
-    .chainInfo()
+    .getLatestBlock()
     .then((x) => {
-      const timestamp = new Date(x.result.bestBlock.timestamp);
+      const timestamp = new Date(x.result.bestBlock.header.timestamp);
       const timeDiff = Date.now() - timestamp;
       const blockHeight = x.result.height;
       console.log("Block #" + blockHeight + " forged at " + timestamp + ".\nThe latest block was created approx. " + Math.floor(timeDiff/1000) + " seconds ago.");
-    });
+    })
+    .catch(e => console.error(e));

--- a/test/testScripts/keyManagerTest.js
+++ b/test/testScripts/keyManagerTest.js
@@ -8,8 +8,9 @@ console.log(h);
 sig = gjal.sign("this is a msg", Buffer.from);
 console.log(sig);
 
-ver = KeyMan.verify(h.address, "this is a msg", sig);
+ver = KeyMan.verify(gjal.pk, "this is a msg", sig);
 console.log(ver);
+console.log(gjal.pk)
 
 gjal.exportToFile("keystore/");
 

--- a/test/ut/modules/keymanager-module.js
+++ b/test/ut/modules/keymanager-module.js
@@ -7,6 +7,7 @@
  */
 
 const KeyManager = require("../../../src/modules/KeyManager");
+const Base58 = require("base-58");
 const assert = require("assert");
 const chai = require('chai');
 const expect = chai.expect;
@@ -288,7 +289,8 @@ describe("KeyManager", () => {
             keyMan.unlockKey("password_test");
 
             // sign with invalid message
-            let signedKey = keyMan.sign("topl_valid_msg");
+            let msg = Base58.encode(Buffer.from("test"))
+            let signedKey = keyMan.sign(msg);
             assert.strictEqual(typeof signedKey, "object");
             assert.strictEqual(signedKey.constructor, Uint8Array);
             assert.strictEqual(signedKey.length, 64);


### PR DESCRIPTION
## Summary
We encountered an issue when attempting to sign and broadcast transactions to Bifrost. After investigation it was found that UTF-8 was being used as the encoding scheme for deriving the Buffer from the string provided by the Bifrost raw transaction.

## Changes
* added `base58` option to `str2buf` function that is used when deriving buffers from string encodings
* specified `base58` for `messageToSign` in a raw transaction and when verifying a signature
* use latin-1 encoding when deriving passwords for keyfiles (in line with Bifrost)

## Testing
* Was able to successfully generate a raw transaction from Bifrost, sign it, then broadcast it back to the node using the `demo.js` test script. The following output was generated
```
{
  rawTx: {
    txType: 'AssetTransfer',
    timestamp: 1615569144645,
    signatures: {},
    newBoxes: [ [Object], [Object] ],
    data: null,
    to: [ [Array], [Array] ],
    propositionType: 'PublicKeyCurve25519',
    from: [ [Array] ],
    minting: true,
    txId: 'eUMVcgNyaJdBSxeuWJcxuVVLck2FxMb55xtU2rbrHnWx',
    boxesToRemove: [ 'FVyRKkseMEJsGoN2x1C5bz86iv7nvSfcEaHLaGP6tw2L' ],
    fee: '1'
  },
  messageToSign: 'R1K57vQqcPBmpbC4XXg4CRxxUNAZ767oQ4prB2Go94W2cesSoivgpDiSFfLa9zvxAwmaeL1U9VkmtbfD7nVsMxY57kXna6Lkz1yksEo5enHXnM2Q5jb52VaPUNHy8AeKUhqxvFM9cYVAmzKarKjn391uLRLhKPBGE7Hi5499ESP5FsTt9Y3cydFdR56bbTD9FKKJoA6VDRJasMc58N7qWEjRe8Seqa4SYbBDWEwzeXJLJLvHS6csxkfyAHvtFuN5zRrTkzsTre1cNeq8gALQHZLWuAVaovdUHepNhyzxcvRG8fTFU3tC4hwztKFDtTyct72YEDVoEFRvYiJpZ2ykk3GUr4'
}
R1K57vQqcPBmpbC4XXg4CRxxUNAZ767oQ4prB2Go94W2cesSoivgpDiSFfLa9zvxAwmaeL1U9VkmtbfD7nVsMxY57kXna6Lkz1yksEo5enHXnM2Q5jb52VaPUNHy8AeKUhqxvFM9cYVAmzKarKjn391uLRLhKPBGE7Hi5499ESP5FsTt9Y3cydFdR56bbTD9FKKJoA6VDRJasMc58N7qWEjRe8Seqa4SYbBDWEwzeXJLJLvHS6csxkfyAHvtFuN5zRrTkzsTre1cNeq8gALQHZLWuAVaovdUHepNhyzxcvRG8fTFU3tC4hwztKFDtTyct72YEDVoEFRvYiJpZ2ykk3GUr4
{
  jsonrpc: '2.0',
  id: '1',
  result: {
    txType: 'AssetTransfer',
    timestamp: 1615569144645,
    signatures: {
      QPoDQgrcZVtq7LfBBAiyFaHaVQ8CKvohNmkx1c6T71P2: '8UGkMXswpPMgYMZpxG9S9vUb18VtDgnCYgfVdbZLPfKk36J6i2UoRAyPcQCGSVHvscdUdicjaB2eScivXQZAWLXq'
    },
    newBoxes: [ [Object], [Object] ],
    data: null,
    to: [ [Array], [Array] ],
    propositionType: 'PublicKeyCurve25519',
    from: [ [Array] ],
    minting: true,
    txId: 'eUMVcgNyaJdBSxeuWJcxuVVLck2FxMb55xtU2rbrHnWx',
    boxesToRemove: [ 'FVyRKkseMEJsGoN2x1C5bz86iv7nvSfcEaHLaGP6tw2L' ],
    fee: '1'
  }
}
```