### PR TITLE
#82 Extract address-utils module in BramblJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,27 @@ console.log(signedKey);
 ```
 <br/><br/>
 
+## Address Utils Module
+The `Address Utilities` are functions used in BramblJS to validate addresses, create asset codes, validate an address network etc. For all available methods see address-utils.js.
+<br/><br/>
+
+### 1a. Import the utilities outside BramblJS module
+```
+const BramblJS = require('brambljs');
+console.log("Valid Networks: " + BramblJS.utils.getValidNetworksList());
+```
+_Note: Upon importing brambljs module, the utilities functions can be used without having to create a new instance of Brambl module which generates a new Keyfile (this is an expensive oiperation)._
+
+### 1b. Import the utilities module using BramblJS module
+```
+const BramblJS = require('brambljs');
+const brambl = new BramblJS('YOUR_PASS')
+
+// utils are also accesible through brambljs module
+console.log("Valid Networks: " + brambl.utils.getValidNetworksList());
+```
+_Note: If a new instance of BramblJS has been created, the utils can be access through this module._
+
 # Examples
 
 ### Transactions may be issued using the method `brambl.transaction` following instantiation of the class.

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ The `Address Utilities` are functions used in BramblJS to validate addresses, cr
 const BramblJS = require('brambljs');
 console.log("Valid Networks: " + BramblJS.utils.getValidNetworksList());
 ```
-_Note: Upon importing brambljs module, the utilities functions can be used without having to create a new instance of Brambl module which generates a new Keyfile (this is an expensive oiperation)._
+_Note: Upon importing brambljs module, the utilities functions can be used without having to create a new instance of Brambl module which generates a new Keyfile (this is an expensive operation)._
 
 ### 1b. Import the utilities module using BramblJS module
 ```

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
 "use strict";
 
 module.exports = require('./src/Brambl')
+module.exports.utils = require('./src/utils/address-utils');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "brambljs",
   "repository": "https://github.com/Topl/BramblJS",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "index.js",
   "scripts": {
     "lint": "eslint src --ext .js",


### PR DESCRIPTION
Extract address-utils module in BramblJS so it can be imported through NPM Package installation